### PR TITLE
Updating to swift-module v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module wpauswiftcommons
+
+go 1.18
+
+require github.com/ncw/swift/v2 v2.0.1

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,5 @@
-module wpauswiftcommons
+module github.com/oquinena/wpauswiftcommons
 
 go 1.18
 
 require github.com/ncw/swift/v2 v2.0.1
-
-require (
-	github.com/ncw/swift v1.0.53 // indirect
-	github.com/oquinena/wpauswiftcommons v0.0.1
-)

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,8 @@ module wpauswiftcommons
 go 1.18
 
 require github.com/ncw/swift/v2 v2.0.1
+
+require (
+	github.com/ncw/swift v1.0.53 // indirect
+	github.com/oquinena/wpauswiftcommons v0.0.0-20160621140300-e2a3bc35c2b0 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require github.com/ncw/swift/v2 v2.0.1
 
 require (
 	github.com/ncw/swift v1.0.53 // indirect
-	github.com/oquinena/wpauswiftcommons v0.0.0-20160621140300-e2a3bc35c2b0 // indirect
+	github.com/oquinena/wpauswiftcommons v0.0.1
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/oquinena/wpauswiftcommons
+module github.com/FAST2/wpauswiftcommons
 
 go 1.18
 

--- a/wpauswiftcommons.go
+++ b/wpauswiftcommons.go
@@ -1,42 +1,44 @@
 package wpauswiftcommons
 
 import (
-    "github.com/ncw/swift"
-    "fmt"
-    "crypto/md5"
-    "io/ioutil"
-    "encoding/hex"
-    "path/filepath"
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	swift "github.com/ncw/swift/v2"
 )
 
-func CreatePublicContainer(name string, c swift.Connection) {
-    headers := map[string]string{
-        "X-Container-Read": ".r:*",
-    }
-    c.ContainerCreate(name, headers)
+func CreatePublicContainer(ctx context.Context, name string, c swift.Connection) {
+	headers := map[string]string{
+		"X-Container-Read": ".r:*",
+	}
+	c.ContainerCreate(ctx, name, headers)
 }
 
-func UploadFile(container string, prefix string, path string, c swift.Connection) {
-    dat, err := ioutil.ReadFile(path)
-    if (err != nil) {
-        println(err.Error())
-    } else {
-        name := filepath.Base(path)
-        if len(prefix) > 0 {
-            name = prefix + "-" + name
-        }
-        ext := filepath.Ext(path)
-        hasher := md5.New()
-        hasher.Write(dat)
-        md5hash := hex.EncodeToString(hasher.Sum(nil))
+func UploadFile(ctx context.Context, container string, prefix string, path string, c swift.Connection) {
+	dat, err := ioutil.ReadFile(path)
+	if err != nil {
+		println(err.Error())
+	} else {
+		name := filepath.Base(path)
+		if len(prefix) > 0 {
+			name = prefix + "-" + name
+		}
+		ext := filepath.Ext(path)
+		hasher := md5.New()
+		hasher.Write(dat)
+		md5hash := hex.EncodeToString(hasher.Sum(nil))
 
-        fmt.Printf("Uploading %s to container %s\n", name, container)
-        file, err := c.ObjectCreate(container, name, false, md5hash, ext, nil)
-        if (err != nil) {
-            println(err.Error())
-        } else {
-            file.Write(dat)
-        }
-        file.Close()
-    }
+		fmt.Printf("Uploading %s to container %s\n", name, container)
+		file, err := c.ObjectCreate(container, name, false, md5hash, ext, nil)
+		if err != nil {
+			println(err.Error())
+		} else {
+			file.Write(dat)
+		}
+		file.Close()
+	}
 }

--- a/wpauswiftcommons.go
+++ b/wpauswiftcommons.go
@@ -33,9 +33,9 @@ func UploadFile(ctx context.Context, container string, prefix string, path strin
 		md5hash := hex.EncodeToString(hasher.Sum(nil))
 
 		fmt.Printf("Uploading %s to container %s\n", name, container)
-		file, err := c.ObjectCreate(container, name, false, md5hash, ext, nil)
+		file, err := c.ObjectCreate(ctx, container, name, false, md5hash, ext, nil)
 		if err != nil {
-			println(err.Error())
+			fmt.Printf("Error uploading file %s. %s", name, err)
 		} else {
 			file.Write(dat)
 		}

--- a/wpauswiftcommons.go
+++ b/wpauswiftcommons.go
@@ -5,7 +5,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	swift "github.com/ncw/swift/v2"
@@ -19,7 +19,7 @@ func CreatePublicContainer(ctx context.Context, name string, c swift.Connection)
 }
 
 func UploadFile(ctx context.Context, container string, prefix string, path string, c swift.Connection) {
-	dat, err := ioutil.ReadFile(path)
+	dat, err := os.ReadFile(path)
 	if err != nil {
 		println(err.Error())
 	} else {


### PR DESCRIPTION
Changes include proper formatting using "go fmt", proper inclusion of go.mod as well as context as required by github.com/ncw/swift/v2